### PR TITLE
[ADD] sftp_extra_sshd_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The following role variables are relevant:
   * `name`: The Unix name of the user that requires SFTP access.
   * `password`: A password hash for the user to login with.  Blank passwords can be set with `password: ""`.  NOTE: It appears that `UsePAM yes` and `PermitEmptyPassword yes` need to be set in `sshd_config` in order for blank passwords to work properly.  Making those changes currently falls outside the scope of this role and will need to be done externally.
   * `authorized`: A list of files placed in `files/` which contain valid public keys for the SFTP user.
+* `sftp_extra_sshd_config` : Extra configuration that will be added in sshd_config file for the `sftp_group_name`. for example you can add a logging configuration :
+    ```
+    # Logging
+    SyslogFacility AUTH
+    LogLevel INFO
+    ```
 
 
 ## Example Playbook
@@ -53,6 +59,10 @@ The following role variables are relevant:
       - exports
       - { name: public, mode: 755 }
       - other
+    - sftp_extra_sshd_config: |
+      # Logging
+      SyslogFacility AUTH
+      LogLevel INFO
   roles:
     - sftp-server
 ```

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -7,5 +7,8 @@ Match Group {{ sftp_group_name }}
     X11Forwarding no
     ForceCommand internal-sftp
     PasswordAuthentication {% if sftp_allow_passwords %}yes{% else %}no{% endif %}
+    {% if sftp_extra_sshd_config is defined %}
+    {{ sftp_extra_sshd_config }}
+    {% endif %}
 
 # End SFTP-Server block


### PR DESCRIPTION
Add variable **sftp_extra_sshd_config** to allow extra configuration in the sshd_config file for the group defined by the variable sftp_group_name